### PR TITLE
Additional libseccomp functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub const SCMP_ACT_ALLOW: u32 = 0x7fff0000;
 /**
  * Filter attributes
  */
-#[derive(Debug)]
+#[derive(Debug,Clone,Copy)]
 #[repr(C)]
 pub enum scmp_filter_attr {
     _SCMP_FLTATR_MIN,
@@ -49,7 +49,7 @@ pub enum scmp_filter_attr {
 /**
  * Comparison operators
  */
-#[derive(Debug)]
+#[derive(Debug,Clone,Copy)]
 #[repr(C)]
 pub enum scmp_compare {
         _SCMP_CMP_MIN = 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,31 @@ pub enum scmp_compare {
 }
 
 /**
+ * Architecutres
+ */
+#[derive(Debug,Clone,Copy)]
+#[repr(C)]
+pub enum scmp_arch {
+    SCMP_ARCH_NATIVE = 0x0,
+    SCMP_ARCH_X86 = 0x40000003,
+    SCMP_ARCH_X86_64 = 0xc000003e,
+    SCMP_ARCH_X32 = 0x4000003e,
+    SCMP_ARCH_ARM = 0x40000028,
+    SCMP_ARCH_AARCH64 = 0xc00000b7,
+    SCMP_ARCH_MIPS = 0x8,
+    SCMP_ARCH_MIPS64 = 0x80000008,
+    SCMP_ARCH_MIPS64N32 = 0xa0000008,
+    SCMP_ARCH_MIPSEL = 0x40000008,
+    SCMP_ARCH_MIPSEL64 = 0xc0000008,
+    SCMP_ARCH_MIPSEL64N32 = 0xe0000008,
+    SCMP_ARCH_PPC = 0x14,
+    SCMP_ARCH_PPC64 = 0x80000015,
+    SCMP_ARCH_PPC64LE = 0xc0000015,
+    SCMP_ARCH_S390 = 0x16,
+    SCMP_ARCH_S390X = 0x80000016,
+}
+
+/**
  * Argument datum
  */
 #[allow(non_camel_case_types)]
@@ -119,6 +144,34 @@ extern {
      *
      */
     pub fn seccomp_release(ctx: *mut scmp_filter_ctx);
+
+    /**
+     * Adds an architecture to the filter
+     * @param ctx the filter context
+     * @param arch_token the architecture token, e.g. SCMP_ARCH_*
+     *
+     * This function adds a new architecture to the given seccomp filter context.
+     * Any new rules added after this function successfully returns will be added
+     * to this architecture but existing rules will not be added to this
+     * architecture.  If the architecture token is SCMP_ARCH_NATIVE then the native
+     * architecture will be assumed.  Returns zero on success, negative values on
+     * failure.
+     *
+     */
+    pub fn seccomp_arch_add(ctx: *mut scmp_filter_ctx, arch_token: libc::uint32_t) -> libc::c_int;
+
+    /**
+     * Removes an architecture from the filter
+     * @param ctx the filter context
+     * @param arch_token the architecture token, e.g. SCMP_ARCH_*
+     *
+     * This function removes an architecture from the given seccomp filter context.
+     * If the architecture token is SCMP_ARCH_NATIVE then the native architecture
+     * will be assumed.  Returns zero on success, negative values on failure.
+     *
+     */
+    pub fn seccomp_arch_remove(ctx: *mut scmp_filter_ctx, arch_token: libc::uint32_t)-> libc::c_int;
+
     /**
      * Loads the filter into the kernel
      *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,11 @@ extern crate libc;
 pub type scmp_filter_ctx = libc::c_void;
 
 /**
+ * Error retern value
+ */
+pub const __NR_SCMP_ERROR: libc::c_int = -1;
+
+/**
  * Kill the process
  */
 pub const SCMP_ACT_KILL: u32  = 0x00000000;
@@ -155,6 +160,16 @@ extern {
     pub fn seccomp_attr_set(ctx: *mut scmp_filter_ctx,
                          attr: scmp_filter_attr, value: libc::uint32_t) -> libc::c_int;
 
+    /**
+     * Resolve a syscall name to a number
+     * @param name the syscall name
+     *
+     * Resolve the given syscall name to the syscall number.  Returns the syscall
+     * number on success, including negative pseudo syscall numbers (e.g. __PNR_*);
+     * returns __NR_SCMP_ERROR on failure.
+     *
+     */
+    pub fn seccomp_syscall_resolve_name(name: *const libc::c_char) -> libc::c_int;
 
     /**
      * Set the priority of a given syscall


### PR DESCRIPTION
Adds:
seccomp_arch_add
seccomp_arch_remove
seccomp_syscall_resolve_name

Also adds Clone and Copy derives for the enums so they can be easily converted to integers without worrying about borrows.
