### PR TITLE
enable building libseccomp from source (downloaded from github) if it is not already installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Cargo.lock
+target
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "^0.3.9"
+curl = "^0.4.8"
+gcc = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "^0.3.9"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,78 @@
 extern crate pkg_config;
+extern crate curl;
+extern crate gcc;
+
+use std::io::{Write};
+
+use curl::easy::Easy;
 
 fn main() {
 
-    if pkg_config::probe_library("libseccomp").is_err() {
+    if pkg_config::probe_library("ibseccomp").is_err() {
         // libseccomp is not installed as a system library... ideally
         // we would like to build it from source, to make installation
         // easier.
-        panic!("Need libseccomp library (with headers) to be installed!");
+        let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+        let mut tarball = std::fs::File::create(out_dir.join("libseccomp.tar.gz")).unwrap();
+        let mut handle = Easy::new();
+        handle.follow_location(true).unwrap();
+        handle.url("https://github.com/seccomp/libseccomp/releases/download/v2.3.2/libseccomp-2.3.2.tar.gz").unwrap();
+        handle.write_function(move |data| {
+            Ok(tarball.write(data).unwrap())
+        }).unwrap();
+        handle.perform().unwrap();
+
+        run("Trouble untarring source code",
+            std::process::Command::new("tar")
+            .args(&["xzf", "libseccomp.tar.gz"])
+            .current_dir(&out_dir));
+
+        let build_dir = out_dir.join("libseccomp-2.3.2");
+        let src_dir = build_dir.join("src");
+
+        // The following is an unholy hodge-podge of techniques.  I
+        // use ./configure to generate the "config.h" file, which is
+        // used by the library.  But sadly, I can't seem to get make
+        // to cross-compile libseccomp properly, even though I
+        // specified the --host argument to ./configure.  So instead,
+        // I manually determine which files to compile, and then use
+        // the gcc crate, which *does* know how to cross-compile
+        // properly to do the actual building of the library.
+        let mut sources = Vec::new();
+        for f in src_dir.read_dir() {
+            for f in f.flat_map(|f| f.ok()) { // lazy way to ignore errors
+                if f.path().extension() == Some(std::ffi::OsStr::new("c"))
+                    && f.file_name() != std::ffi::OsStr::new("arch-syscall-check.c")
+                    && f.file_name() != std::ffi::OsStr::new("arch-syscall-dump.c") {
+                        sources.push(f.path());
+                    }
+            }
+        }
+        let prefix = out_dir.join("libseccomp");
+
+        let target = std::env::var("TARGET").unwrap();
+        println!("target is {}", target);
+        run("Trouble configuring source code",
+            std::process::Command::new("./configure")
+            .args(&["--enable-shared=no", "--disable-dependency-tracking",
+                    "--prefix",])
+            .arg(prefix)
+            .arg("--host")
+            .arg(target)
+            .current_dir(&build_dir));
+
+        gcc::Build::new()
+            .files(sources)
+            .include(&src_dir)
+            .include(&build_dir)
+            .include(build_dir.join("include"))
+            .compile("libseccomp.a");
+    }
+}
+
+fn run(error_msg: &'static str, cmd: &mut std::process::Command) {
+    if !cmd.status().expect(error_msg).success() {
+        panic!(error_msg);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use curl::easy::Easy;
 
 fn main() {
 
-    if pkg_config::probe_library("ibseccomp").is_err() {
+    if pkg_config::probe_library("libseccomp").is_err() {
         // libseccomp is not installed as a system library... ideally
         // we would like to build it from source, to make installation
         // easier.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+extern crate pkg_config;
+
+fn main() {
+
+    if pkg_config::probe_library("libseccomp").is_err() {
+        // libseccomp is not installed as a system library... ideally
+        // we would like to build it from source, to make installation
+        // easier.
+        panic!("Need libseccomp library (with headers) to be installed!");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,6 @@ pub struct scmp_arg_cmp {
         pub datum_b: scmp_datum_t,
 }
 
-#[link(name = "seccomp")]
 extern {
     /**
      * Initialize the filter state


### PR DESCRIPTION
The build.rs script is more than a big hokey, but it works for me (including cross-compiling to i686), so hopefully it is good enough.