### PR TITLE
Add SCMP_ACT_KILL_PROCESS.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,13 @@ pub type scmp_filter_ctx = libc::c_void;
 pub const __NR_SCMP_ERROR: libc::c_int = -1;
 
 /**
- * Kill the process
+ * Kill the calling thread
  */
 pub const SCMP_ACT_KILL: u32  = 0x00000000;
+/**
+ * Kill the calling process
+ */
+pub const SCMP_ACT_KILL_PROCESS: u32 = 0x80000000;
 /**
  * Throw a SIGSYS signal
  */


### PR DESCRIPTION
The existing SCMP_ACT_KILL only kills the calling _thread_, not
the whole process. This was a mistake in the implementation of
seccomp. SCMP_ACT_KILL_PROCESS was added later (linux v4.14) to
implement the intuitive behavior.