### PR TITLE
Support to resolve syscall number to syscall name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,18 @@ extern {
     pub fn seccomp_syscall_resolve_name(name: *const libc::c_char) -> libc::c_int;
 
     /**
+     * Resolve a syscall number to a name
+     * @param arch_token the architecture token, e.g. SCMP_ARCH_*
+     * @param num the syscall number
+     *
+     * Resolve the given syscall number to the syscall name for the given
+     * architecture; it is up to the caller to free the returned string.  Returns
+     * the syscall name on success, NULL on failure.
+     *
+     */
+    pub fn seccomp_syscall_resolve_num_arch(arch_token: u32, num: libc::c_int) -> *const libc::c_char;
+
+    /**
      * Set the priority of a given syscall
      *
      * @param ctx the filter context


### PR DESCRIPTION
- Libseccomp has the API support to convert given syscall number to syscall name for given architecture.
  - [seccomp.h.in#L593](https://github.com/seccomp/libseccomp/blob/master/include/seccomp.h.in#L593)
- This patch adds support for `seccomp_syscall_resolve_num_arch` 
- **Example**
```
extern crate libc;
extern crate seccomp_sys;
use std::ffi::CStr;
use std::str;

fn main() {
    unsafe {
        let syscall_num = 0;
        let c_buf = seccomp_sys::seccomp_syscall_resolve_num_arch(seccomp_sys::scmp_arch::SCMP_ARCH_X86_64 as u32,syscall_num );
        let c_str: &CStr = CStr::from_ptr(c_buf);
        let str_slice: &str = c_str.to_str().unwrap();
        println!("syscall num: {} -> syscall name: {}", syscall_num, str_slice.to_string());
    }
}
```
- **Output**
```
syscall num: 0 -> syscall name: read
```