### PR TITLE
Add seccomp notify support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+extern crate pkg_config;
 use std::env;
 
 fn main() {
@@ -17,4 +18,13 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", rustc_link_search),
         Err(_) => {}
     };
+
+    if pkg_config::Config::new()
+        .atleast_version("2.5.0")
+        .probe("libseccomp")
+        .is_ok()
+    {
+
+        println!("cargo:rustc-cfg=seccomp_notify");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,7 @@ extern {
      * success, and negative values on failure.
      *
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_alloc(req: *mut *mut seccomp_notif,
                                 resp: *mut *mut seccomp_notif_resp) -> libc::c_int;
 
@@ -423,6 +424,7 @@ extern {
      * @param req the request location
      * @param resp the response location
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_free(req: *mut seccomp_notif,
                                resp: *mut seccomp_notif_resp) -> libc::c_void;
 
@@ -436,6 +438,7 @@ extern {
      * negative values on error.
      *
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_receive(fd: libc::c_int, req: *mut seccomp_notif) -> libc::c_int;
 
     /**
@@ -448,6 +451,7 @@ extern {
      * negative values on error.
      *
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_respond(fd: libc::c_int, resp: *mut seccomp_notif_resp) -> libc::c_int;
 
     /**
@@ -459,6 +463,7 @@ extern {
      * negative values on failure.
      *
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_id_valid(fd: libc::c_int, id: u64) -> libc::c_int;
 
     /**
@@ -470,6 +475,7 @@ extern {
      * use of SCMP_ACT_NOTIFY.
      *
      */
+    #[cfg(seccomp_notify)]
     pub fn seccomp_notify_fd(ctx: *const scmp_filter_ctx) -> libc::c_int;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@ pub fn SCMP_ACT_TRACE(x: u32) -> u32 { 0x7ff00000 | ((x) & 0x0000ffff) }
  * Allow the syscall to be executed
  */
 pub const SCMP_ACT_ALLOW: u32 = 0x7fff0000;
+/**
+ * Notify userspace
+ */
+pub const SCMP_ACT_NOTIFY: u32 = 0x7fc00000;
 
 /**
  * Filter attributes
@@ -111,6 +115,42 @@ pub struct scmp_arg_cmp {
         pub op: scmp_compare,       /** the comparison op, e.g. SCMP_CMP_* */
         pub datum_a: scmp_datum_t,
         pub datum_b: scmp_datum_t,
+}
+
+/**
+ * struct seccomp_data - the format the BPF program executes over.
+ * @nr: the system call number
+ * @arch: indicates system call convention as an AUDIT_ARCH_* value
+ *        as defined in <linux/audit.h>.
+ * @instruction_pointer: at the time of the system call.
+ * @args: up to 6 system call arguments always stored as 64-bit values
+ *        regardless of the architecture.
+ */
+#[derive(Debug)]
+#[repr(C)]
+pub struct seccomp_data {
+    pub nr: libc::c_int,
+    pub arch: u32,
+    pub instruction_pointer: u64,
+    pub args: [u64; 6],
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct seccomp_notif {
+    pub id: u64,
+    pub pid: u32,
+    pub flags: u32,
+    pub data: seccomp_data,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct seccomp_notif_resp {
+    pub id: u64,
+    pub val: i64,
+    pub error: i32,
+    pub flags: u32,
 }
 
 #[link(name = "seccomp")]
@@ -364,6 +404,73 @@ extern {
      *
      */
     pub fn seccomp_export_bpf(ctx: *const scmp_filter_ctx, fd: libc::c_int) -> libc::c_int;
+
+    /**
+     * Allocate a pair of notification request/response structures
+     * @param req the request location
+     * @param resp the response location
+     *
+     * This function allocates a pair of request/response structure by computing
+     * the correct sized based on the currently running kernel. It returns zero on
+     * success, and negative values on failure.
+     *
+     */
+    pub fn seccomp_notify_alloc(req: *mut *mut seccomp_notif,
+                                resp: *mut *mut seccomp_notif_resp) -> libc::c_int;
+
+    /**
+     * Free a pair of notification request/response structures.
+     * @param req the request location
+     * @param resp the response location
+     */
+    pub fn seccomp_notify_free(req: *mut seccomp_notif,
+                               resp: *mut seccomp_notif_resp) -> libc::c_void;
+
+    /**
+     * Receive a notification from a seccomp notification fd
+     * @param fd the notification fd
+     * @param req the request buffer to save into
+     *
+     * Blocks waiting for a notification on this fd. This function is thread safe
+     * (synchronization is performed in the kernel). Returns zero on success,
+     * negative values on error.
+     *
+     */
+    pub fn seccomp_notify_receive(fd: libc::c_int, req: *mut seccomp_notif) -> libc::c_int;
+
+    /**
+     * Send a notification response to a seccomp notification fd
+     * @param fd the notification fd
+     * @param resp the response buffer to use
+     *
+     * Sends a notification response on this fd. This function is thread safe
+     * (synchronization is performed in the kernel). Returns zero on success,
+     * negative values on error.
+     *
+     */
+    pub fn seccomp_notify_respond(fd: libc::c_int, resp: *mut seccomp_notif_resp) -> libc::c_int;
+
+    /**
+     * Check if a notification id is still valid
+     * @param fd the notification fd
+     * @param id the id to test
+     *
+     * Checks to see if a notification id is still valid. Returns 0 on success, and
+     * negative values on failure.
+     *
+     */
+    pub fn seccomp_notify_id_valid(fd: libc::c_int, id: u64) -> libc::c_int;
+
+    /**
+     * Return the notification fd from a filter that has already been loaded
+     * @param ctx the filter context
+     *
+     * This returns the listener fd that was generated when the seccomp policy was
+     * loaded. This is only valid after seccomp_load() with a filter that makes
+     * use of SCMP_ACT_NOTIFY.
+     *
+     */
+    pub fn seccomp_notify_fd(ctx: *const scmp_filter_ctx) -> libc::c_int;
 }
 
 #[test]


### PR DESCRIPTION
Linux 5.0 introduced the “Seccomp Notify” feature, which can be used to let a seccomp agent on the host perform privileged system calls. 
The reference link is below.
https://www.kernel.org/doc/html/v5.0/userspace-api/seccomp_filter.html#userspace-notification
https://man7.org/linux/man-pages/man3/seccomp_notify_fd.3.html

Seccomp notify is available from libseccomp v2.50, so I would like to add the seccomp notify api in this crate.
Unfortunately,  libseccoomp >= v2.5.0 is not available as dpkg package in most distros as of Sep 2020.
Therefore,  We need to install libseccomp v2.50 from source to use the feature.

If there are any inconveniences about the existing ecosystem, please let me know.