### PR TITLE
Add seccomp_arch_resolve_name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,16 @@ extern "C" {
     pub fn seccomp_arch_remove(ctx: *mut scmp_filter_ctx, arch_token: u32) -> libc::c_int;
 
     /**
+     * Resolve the architecture name to a architecture token
+     * @param arch_name the architecture name
+     *
+     * This function resolves the given architecture name to a token suitable for
+     * use with libseccomp, returns zero on failure.
+     *
+     */
+    pub fn seccomp_arch_resolve_name(arch_name: *const libc::c_char) -> libc::c_uint;
+
+    /**
      * Loads the filter into the kernel
      *
      * @param ctx the filter context


### PR DESCRIPTION
I'd like to add seccomp_arch_resolve_name function.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>